### PR TITLE
notion form support

### DIFF
--- a/packages/notion-client/src/notion-api.ts
+++ b/packages/notion-client/src/notion-api.ts
@@ -52,7 +52,8 @@ export class NotionAPI {
       chunkLimit = 100,
       chunkNumber = 0,
       fetchRelationPages = false,
-      kyOptions
+      kyOptions,
+      embeddedFormsBaseUrl
     }: {
       concurrency?: number
       fetchMissingBlocks?: boolean
@@ -62,6 +63,7 @@ export class NotionAPI {
       chunkNumber?: number
       fetchRelationPages?: boolean
       kyOptions?: KyOptions
+      embeddedFormsBaseUrl?: string
     } = {}
   ): Promise<notion.ExtendedRecordMap> {
     const page = await this.getPageRaw(pageId, {
@@ -205,6 +207,10 @@ export class NotionAPI {
     if (fetchRelationPages) {
       const newBlocks = await this.fetchRelationPages(recordMap, kyOptions)
       recordMap.block = { ...recordMap.block, ...newBlocks }
+    }
+
+    if (embeddedFormsBaseUrl) {
+      recordMap.embeddedFormsBaseUrl = embeddedFormsBaseUrl
     }
 
     return recordMap

--- a/packages/notion-types/src/block.ts
+++ b/packages/notion-types/src/block.ts
@@ -44,6 +44,7 @@ export type BlockType =
   | 'external_object_instance'
   | 'breadcrumb'
   | 'miro'
+  | 'form'
   // fallback for unknown blocks
   | string
 
@@ -91,6 +92,7 @@ export type Block =
   | TableRowBlock
   | ExternalObjectInstance
   | BreadcrumbInstance
+  | FormBlock
 
 /**
  * Base properties shared by all blocks.
@@ -469,4 +471,20 @@ export interface ExternalObjectInstance extends BaseBlock {
 
 export interface BreadcrumbInstance extends BaseBlock {
   type: 'breadcrumb'
+}
+
+export interface FormBlock extends BaseBlock {
+  type: 'form'
+  format: {
+    site_id: string
+    form_config?: {
+      anonymous_submissions?: boolean
+      submission_permissions?: string
+    }
+    form_layout_pointer?: {
+      id: string
+      table: string
+      spaceId: string
+    }
+  }
 }

--- a/packages/react-notion-x/src/block.tsx
+++ b/packages/react-notion-x/src/block.tsx
@@ -14,6 +14,7 @@ import { AssetWrapper } from './components/asset-wrapper'
 import { Audio } from './components/audio'
 import { EOI } from './components/eoi'
 import { File } from './components/file'
+import { Form } from './components/form'
 import { GoogleDrive } from './components/google-drive'
 import { LazyImage } from './components/lazy-image'
 import { PageAside } from './components/page-aside'
@@ -763,6 +764,15 @@ export function Block(props: BlockProps) {
       if (!linkedBlock) {
         console.log('"alias" missing block', blockPointerId)
         return null
+      }
+
+      if ((linkedBlock as types.FormBlock)?.type === 'form') {
+        return (
+          <Form
+            block={linkedBlock}
+            embeddedFormsBaseUrl={recordMap.embeddedFormsBaseUrl}
+          />
+        )
       }
 
       return (

--- a/packages/react-notion-x/src/components/form.tsx
+++ b/packages/react-notion-x/src/components/form.tsx
@@ -1,0 +1,19 @@
+export function Form({
+  block,
+  embeddedFormsBaseUrl
+}: {
+  block: any
+  embeddedFormsBaseUrl: string
+}) {
+  const formId = block?.id?.replace(/-/g, '')
+  return (
+    <iframe
+      className='notion-form-iframe'
+      src={`${embeddedFormsBaseUrl}/ebd/${formId}`}
+      width='100%'
+      height='600'
+      allowFullScreen
+      title={`Notion Form: ${block?.id}`}
+    />
+  )
+}

--- a/packages/react-notion-x/src/context.tsx
+++ b/packages/react-notion-x/src/context.tsx
@@ -151,7 +151,8 @@ const defaultNotionContext: NotionContext = {
     collection_view: {},
     collection_query: {},
     notion_user: {},
-    signed_urls: {}
+    signed_urls: {},
+    embeddedFormsBaseUrl: ''
   },
 
   components: defaultComponents,


### PR DESCRIPTION
✨ Added Support for Notion Form Blocks
This PR adds support for rendering Notion Form blocks using a standard <iframe>, with a customizable embed source.

The user must provide the embeddedFormBaseUrl which is then used to generate the full form embed URL in the format:

[embeddedFormBaseUrl]/ebd/[formId]
The iframe is rendered with a .notion-form-iframe class to allow global styling and layout customization.

<iframe
  src="[embeddedFormBaseUrl]/ebd/[formId]"
  class="notion-form-iframe"
  width="100%"
  height="600"
/>
🎯 Notes
The embedded form inherits its theme (light/dark) from the Notion Site settings.
This approach matches Notion’s native public site behavior.
Developers can customize iframe appearance using .notion-form-iframe in global styles.